### PR TITLE
Make Astro's logo light when in dark mode

### DIFF
--- a/src/components/Skill.astro
+++ b/src/components/Skill.astro
@@ -16,3 +16,9 @@ const { text, logo } = Astro.props;
   </span>
   <span class="dark:text-zinc-400 text-zinc-600">{text}</span>
 </li>
+
+<style is:global>
+  [astro-icon="simple-icons:astro"] {
+    @apply dark:text-white;
+  }
+</style>


### PR DESCRIPTION
Hey there! Just wanted to say that your website looks neat :)

This PR is just a minor pet peeve of mine as it's kind of hard for me to see Astro's logo under the Favorite Technologies tab when I'm in dark mode.