### PR TITLE
Fixing shift because of scroll behavior

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -64,7 +64,7 @@ const canonicalURL = new URL(Astro.url).href;
     }
   </head>
   <body
-    class="dark:bg-zinc-900 bg-zinc-100 antialiased selection:bg-teal-300 selection:text-zinc-900 dark:selection:bg-teal-600 dark:selection:text-white pt-10 pb-20 2xl:text-lg"
+    class="dark:bg-zinc-900 bg-zinc-100 antialiased selection:bg-teal-300 selection:text-zinc-900 dark:selection:bg-teal-600 dark:selection:text-white pt-10 pb-20 2xl:text-lg overflow-scroll"
   >
     <a
       href="#main-content"


### PR DESCRIPTION
You can notice a shift on the top menu when going from a page with scrollbar to one without, this PR fixes that. 
This fixes #104 